### PR TITLE
Add prud user-agent header

### DIFF
--- a/core/prud/feedutil.py
+++ b/core/prud/feedutil.py
@@ -52,7 +52,11 @@ def _raw_post_to_object(raw_post, feed_id) -> pruddb.PolyRingPost:
 
 def posts_from_feed(feed: pruddb.PolyRingFeed) -> list[pruddb.PolyRingPost]:
     try:
-        response = requests.get(feed.feed, timeout=config.feed_request_timeout)
+        response = requests.get(
+            feed.feed,
+            timeout=config.feed_request_timeout,
+            headers={"User-Agent": "prud (+https://github.com/Nighmared/prud)"},
+        )
     except requests.exceptions.Timeout as exc:
         raise ConnectionError("Timed out") from exc
     except requests.exceptions.ConnectionError as exc:

--- a/core/prud/polyring.py
+++ b/core/prud/polyring.py
@@ -13,7 +13,11 @@ logger = loguru.logger
 
 def get_online_feeds() -> list[pruddb.PolyRingFeed]:
     try:
-        response = requests.get(config.polyring_members_url, timeout=10)
+        response = requests.get(
+            config.polyring_members_url,
+            timeout=10,
+            headers={"User-Agent": "prud (+https://github.com/Nighmared/prud)"},
+        )
     except TimeoutError as exc:
         raise ValueError("Couldn't reach polyring website within timeout") from exc
     feeds: list[pruddb.PolyRingFeed] = []


### PR DESCRIPTION
Noticed there was no User-Agent in the requests, so the blog was just being scraped by a random `python-requests/2.32.5`. Small change that gives a bit more info for people curious about where requests are coming from.